### PR TITLE
AWS CLI profile as variable

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=3.28.0"
+      version = "4.9"
     }
   }
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -10,5 +10,6 @@ terraform {
 }
 
 provider "aws" {
-  region = var.region
+  region  = var.region
+  profile = var.aws_cli_profile != "" ? var.aws_cli_profile : "default"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -14,3 +14,8 @@ variable "minikube_instance_name" {
   description = "Minikube EC2 Instance name"
   default     = "minikube-on-ec2"
 }
+
+variable "aws_cli_profile" {
+  type        = string
+  description = "AWS CLI configuration profile to use (empty for default)"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -6,7 +6,7 @@ variable "region" {
 
 variable "kubeconfig_output_location" {
   type        = string
-  description = "KubeConfig file Location"
+  description = "KubeConfig file Location (relative path)"
 }
 
 variable "minikube_instance_name" {


### PR DESCRIPTION
This PR does the following:
- Add prompt to specify AWS CLI profile, with option to leave blank to use default profile
- Add to the kubeconfig path prompt that the path is relative to the current directory and not an absolute path
- Update AWS provider to version 4.9 . 

Any feedback/comments is welcome ;)