### PR TITLE
feat: add alarm to shutdown idle instances

### DIFF
--- a/alarms.tf
+++ b/alarms.tf
@@ -1,0 +1,15 @@
+resource "aws_cloudwatch_metric_alarm" "shutdown_idle" {
+  alarm_name          = "shutdown idle ec2 : ${var.minikube_instance_name}"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = "3600" # 1 hour
+  statistic           = "Average"
+  threshold           = "10"
+  alarm_description   = "This metric monitors ec2 cpu utilization"
+  alarm_actions       = ["arn:aws:automate:${var.region}:ec2:stop"]
+  dimensions = {
+    InstanceId = "${aws_instance.minikube_instance.id}"
+  }
+}


### PR DESCRIPTION
## Scope

Sometimes instances are ignored after use, It happens.
This PR aims to help avoid unnecessary costs by shutting down instances that go idle for too long.

## Scenario

- monitor average CPU utilization of instance
- if the average over 2 hours is less than 10 percent, trigger action
- action stops the instance without causing loss of data